### PR TITLE
azurepowershell: update PowerShell version requirement

### DIFF
--- a/automatic/azurepowershell/azurepowershell.nuspec
+++ b/automatic/azurepowershell/azurepowershell.nuspec
@@ -17,7 +17,7 @@
     <summary>Azure PowerShell provides a set of cmdlets that use the Azure Resource Manager model for managing your Azure resources.</summary>
     <description>Azure PowerShell provides a set of cmdlets that use the Azure Resource Manager model for managing your Azure resources. You can use it in your browser with Azure Cloud Shell, or you can install it on your local machine and use it in any PowerShell session.
 
-Azure PowerShell requires PowerShell 3.0 or later, which can be installed using the [powershell](https://chocolatey.org/packages/powershell) package. This package does not define a dependency on that package to avoid causing a potentially undesired update to the newest PowerShell.
+Azure PowerShell requires PowerShell 5.0 or later, which can be installed using the [powershell](https://chocolatey.org/packages/powershell) package. This package does not define a dependency on that package to avoid causing a potentially undesired update to the newest PowerShell.
 </description>
     <releaseNotes>
 ##### Software
@@ -27,8 +27,8 @@ Azure PowerShell requires PowerShell 3.0 or later, which can be installed using 
     </releaseNotes>
     <dependencies>
       <dependency id="dotnet4.5.2" version="4.5.2.20140902" />
-      <!-- PS 3.0+ is required, but such a dependency would cause installation of the newest PowerShell and users might not like that -->
-      <!-- <dependency id="powershell" version="3.0" /> -->
+      <!-- PS 5.0+ is required, but such a dependency would cause installation of the newest PowerShell and users might not like that -->
+      <!-- <dependency id="powershell" version="5.0" /> -->
     </dependencies>
   </metadata>
   <files>

--- a/automatic/azurepowershell/tools/ChocolateyInstall.ps1
+++ b/automatic/azurepowershell/tools/ChocolateyInstall.ps1
@@ -9,7 +9,7 @@ $checksumType = 'SHA256'
 
 . (Join-Path -Path (Split-Path -Path $MyInvocation.MyCommand.Path) -ChildPath helpers.ps1)
 
-Ensure-RequiredPowerShellVersionPresent -RequiredVersion '3.0'
+Ensure-RequiredPowerShellVersionPresent -RequiredVersion '5.0'
 
 if (Test-AzurePowerShellInstalled -RequiredVersion $moduleVersion)
 {


### PR DESCRIPTION
The module now requires PS 5.