### PR TITLE
Updated setup download url for TeamViewer 14

### DIFF
--- a/automatic/teamviewer/update.ps1
+++ b/automatic/teamviewer/update.ps1
@@ -22,10 +22,11 @@ function global:au_GetLatest {
     $tempFile = New-TemporaryFile
     Invoke-WebRequest -Uri $releases -OutFile $tempFile -UseBasicParsing
     $fileVer = (Get-Item $tempfile).VersionInfo
+    $versionForURL = "$($fileVer.ProductMajorPart)"
     $version = "$($fileVer.ProductMajorPart).$($fileVer.ProductMinorPart).$($fileVer.ProductBuildPart)"
 
     return @{
-        URL32   = $releases
+        URL32   = "https://download.teamviewer.com/download/version_${versionForURL}x/TeamViewer_Setup.exe"
         Version = $version
     }
 }

--- a/automatic/teamviewer/update.ps1
+++ b/automatic/teamviewer/update.ps1
@@ -26,7 +26,7 @@ function global:au_GetLatest {
     $version = "$($fileVer.ProductMajorPart).$($fileVer.ProductMinorPart).$($fileVer.ProductBuildPart)"
 
     return @{
-        URL32   = "https://download.teamviewer.com/download/version_${versionForURL}x/TeamViewer_Setup.exe"
+        URL32   = "https://download.teamviewer.com/download/version_$(versionForURL)x/TeamViewer_Setup.exe"
         Version = $version
     }
 }


### PR DESCRIPTION
In this comment you can see the reason for this change.
https://chocolatey.org/packages/teamviewer#comment-4206081411

    choco install teamviewer --version 13

will install the newest version without this change.
So lets change the download algorithm so that only the current deployed version is used for the download.
If the package is updated to version 15 later we can change it easily but whoever wants to install version 14 is then only downloading version 14.