### PR TITLE
virtualbox-guest-additions-install: Remove AHK dependency

### DIFF
--- a/automatic/virtualbox-guest-additions-guest.install/virtualbox-guest-additions-guest.install.nuspec
+++ b/automatic/virtualbox-guest-additions-guest.install/virtualbox-guest-additions-guest.install.nuspec
@@ -75,14 +75,14 @@ The Windows and Linux Guest Additions therefore check automatically whether they
         <!-- =============================== -->
 
         <!-- Specifying dependencies and version ranges? https://docs.nuget.org/create/versioning#specifying-version-ranges-in-.nuspec-files -->
-        <dependencies>
-            <dependency id="autohotkey" />
+        <!-- <dependencies>
+            <dependency id="autohotkey" /> -->
         <!--    <dependency id="" version="[__EXACT_VERSION__]" />
             <dependency id="" version="[_MIN_VERSION_INCLUSIVE, MAX_VERSION_INCLUSIVE]" />
             <dependency id="" version="[_MIN_VERSION_INCLUSIVE, MAX_VERSION_EXCLUSIVE)" />
             <dependency id="" />
             <dependency id="chocolatey-core.extension" version="1.1.0" /> -->
-        </dependencies>
+        <!-- </dependencies> -->
         <!-- chocolatey-core.extension - https://chocolatey.org/packages/chocolatey-core.extension
          - You want to use Get-UninstallRegistryKey on less than 0.9.10 (in chocolateyUninstall.ps1)
          - You want to use Get-PackageParameters and on less than 0.11.0


### PR DESCRIPTION
Remove the AHK dependency missed from PR #42 which was spotted by @brycebeagle

Closes #41 