### PR TITLE
Adding automatic packaging for x86 hugo

### DIFF
--- a/automatic/hugo/hugo.nuspec
+++ b/automatic/hugo/hugo.nuspec
@@ -23,7 +23,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
         <!-- version should MATCH as closely as possible with the underlying software -->
         <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
         <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-        <version>0.51</version>
+        <version>0.71.0</version>
         <packageSourceUrl>https://github.com/pauby/chocopackages/tree/master/automatic/hugo</packageSourceUrl>
         <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
         <owners>pauby, switchspan</owners>
@@ -54,7 +54,7 @@ Hugo renders a typical website of moderate size in a fraction of a second. A goo
 Hugo is designed to work well for any kind of website including blogs, tumbles, and docs.
 
 **NOTE**: This is an automatically updated package. If you find it is out of date by more than a week, please contact the maintainer(s) and let them know the package is no longer updating correctly.
-        </description>
+</description>
         <releaseNotes>https://github.com/gohugoio/hugo/releases</releaseNotes>
         <!-- =============================== -->
         <!-- Specifying dependencies and version ranges? https://docs.nuget.org/create/versioning#specifying-version-ranges-in-.nuspec-files -->

--- a/automatic/hugo/tools/chocolateyInstall.ps1
+++ b/automatic/hugo/tools/chocolateyInstall.ps1
@@ -5,13 +5,13 @@ $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $packageArgs = @{
     packageName    = $env:ChocolateyPackageName
     unzipLocation  = $toolsDir
-    url            = 'https://github.com//gohugoio/hugo/releases/download/v0.51/hugo_0.51_Windows-32bit.zip'
-    url64          = 'https://github.com//gohugoio/hugo/releases/download/v0.51/hugo_0.51_Windows-64bit.zip'
+    url            = 'https://github.com//gohugoio/hugo/releases/download/v0.71.0/hugo_0.71.0_Windows-32bit.zip'
+    url64          = 'https://github.com//gohugoio/hugo/releases/download/v0.71.0/hugo_0.71.0_Windows-64bit.zip'
 
-    checksum       = 'BB6AE1134F2772D77A257C81DF526518406429918D636E3A0CB05D853A1E486E'
-    checksumType   = 'sha256'
-    checksum64     = 'A2ECE21BD629481E88AAFAE413FB6DA23BE3F7967753E8F09CBE40A12EC14921'
-    checksumType64 = 'sha256'
+    checksum       = '3b384bb8ace81e083d021e93f38e86207ee3eb0969d75d003eb6ab4a868301b8'
+    checksumType   = 'SHA256'
+    checksum64     = 'b84abcc4fcd5b990dab8399198eedefdf5b560aad09ece7a25c1fd806d53b2a4'
+    checksumType64 = 'SHA256'
 }
 
 Install-ChocolateyZipPackage @packageArgs

--- a/automatic/hugo/update.ps1
+++ b/automatic/hugo/update.ps1
@@ -7,6 +7,9 @@ $releases    = 'https://github.com/gohugoio/hugo/releases'
 function global:au_SearchReplace {
     @{
         ".\tools\chocolateyInstall.ps1" = @{
+            '(^\s*url\s*=\s*)(''.*'')'              = "`$1'$($Latest.URL32)'"
+            "(?i)(^\s*checksum\s*=\s*)('.*')"       = "`$1'$($Latest.Checksum32)'"
+            "(?i)(^\s*checksumType\s*=\s*)('.*')"   = "`$1'$($Latest.ChecksumType32)'"
             '(^\s*url64\s*=\s*)(''.*'')'            = "`$1'$($Latest.URL64)'"
             "(?i)(^\s*checksum64\s*=\s*)('.*')"       = "`$1'$($Latest.Checksum64)'"
             "(?i)(^\s*checksumType64\s*=\s*)('.*')"   = "`$1'$($Latest.ChecksumType64)'"
@@ -15,6 +18,10 @@ function global:au_SearchReplace {
 }
 
 function global:au_BeforeUpdate {
+    $Latest.Checksum32 = Get-RemoteChecksum $Latest.Url32
+    $Latest.ChecksumType32 = 'SHA256'
+    $Latest.Checksum64 = Get-RemoteChecksum $Latest.Url64
+    $Latest.ChecksumType64 = 'SHA256'
 }
 
 function global:au_AfterUpdate {
@@ -23,14 +30,18 @@ function global:au_AfterUpdate {
 
 function global:au_GetLatest {
     $page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-    $regexUrl = '/hugo_(?<version>[\d\.]+)_Windows-64bit\.zip'
 
-    $url = $page.links | Where-Object href -match $regexUrl | Select-Object -First 1 -expand href
+    $regexUrl32 = '/hugo_(?<version>[\d\.]+)_Windows-32bit\.zip'
+    $regexUrl64 = '/hugo_(?<version>[\d\.]+)_Windows-64bit\.zip'
+
+    $url32 = $page.links | Where-Object href -match $regexUrl32 | Select-Object -First 1 -expand href
+    $url64 = $page.links | Where-Object href -match $regexUrl64 | Select-Object -First 1 -expand href
 
     return @{
-        URL64        = "https://github.com/$url"
+        URL32        = "https://github.com/$url32"
+        URL64        = "https://github.com/$url64"
         Version      = $matches.version
     }
 }
 
-update -ChecksumFor 64
+update -ChecksumFor none


### PR DESCRIPTION
This PR resolves #53 

The issue whereby forcing choco to install the x86 version of hugo resulted in an outdated version being installed is resolved with this PR. It was initially highlighted in the main repo.
https://github.com/gohugoio/hugo/issues/7186

Also on a side-note bumps the install script and package to v0.71.0 the latest available and a small change to the checksum logic 👍 

Cheers for maintaining the package!