### PR TITLE
Fixed checking for old versions

### DIFF
--- a/automatic/keepass-plugin-readablepassphrasegen/tools/chocolateyInstall.ps1
+++ b/automatic/keepass-plugin-readablepassphrasegen/tools/chocolateyInstall.ps1
@@ -36,8 +36,8 @@ else {
     Write-Verbose "Found Keepass install location at '$installPath'."
 }
 
-$oldPackageVersion = Get-ChildItem -Path Test-Path -Path (Join-Path -Path $installPath -ChildPath 'ReadablePassphrase*.plgx')
-if ($oldPackageVersion) {
+$oldPackageVersion = Join-Path -Path $installPath -ChildPath 'ReadablePassphrase*.plgx'
+if (Test-Path $oldPackageVersion) {
     Write-Verbose 'Found old versions of this plugin. Removing.'
     $oldPackageVersion | Remove-Item -ErrorAction SilentlyContinue
 }


### PR DESCRIPTION
The statement for declaring the $oldPackageVersion variable was throwing an exception