### PR TITLE
Update/keepass readable scripts

### DIFF
--- a/automatic/keepass-plugin-readablepassphrasegen/keepass-plugin-readablepassphrasegen.nuspec
+++ b/automatic/keepass-plugin-readablepassphrasegen/keepass-plugin-readablepassphrasegen.nuspec
@@ -23,7 +23,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
         <!-- version should MATCH as closely as possible with the underlying software -->
         <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
         <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-        <version>1.2.1</version>
+        <version>1.1.1</version>
         <packageSourceUrl>https://github.com/pauby/ChocoPackages/tree/master/automatic/keepass-plugin-readablepassphrasegen</packageSourceUrl>
         <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
         <owners>pauby</owners>

--- a/automatic/keepass-plugin-readablepassphrasegen/update.ps1
+++ b/automatic/keepass-plugin-readablepassphrasegen/update.ps1
@@ -11,6 +11,9 @@ function global:au_SearchReplace {
             "(?i)(^\s*checksum\s*=\s*)('.*')"       = "`$1'$($Latest.Checksum32)'"
             "(?i)(^\s*checksumType\s*=\s*)('.*')"   = "`$1'$($Latest.ChecksumType32)'"
         }
+        ".\tools\chocolateyUninstall.ps1" = @{
+            '(^\s*\$pluginFilename\s*=\s*)(''ReadablePassphrase%20.*'')' = "`$1'ReadablePassphrase%20$($Latest.Version).plgx'"
+        }
     }
 }
 


### PR DESCRIPTION
Hi,

This is the first solution to issue #65 .

I updated the update script to also update `chocolateyUninstall.ps1`.

I reset the version in nuget package because it did not match what was in the scripts.
I thought this was necessary so that the automatic update can work properly.

I hope this helps.