### PR TITLE
Solve files not getting ignored for shimming on Gitter package

### DIFF
--- a/automatic/gitter/tools/chocolateyInstall.ps1
+++ b/automatic/gitter/tools/chocolateyInstall.ps1
@@ -11,9 +11,10 @@ $packageArgs = @{
     validExitCodes = @(0)
 }
 
-Install-ChocolateyInstallPackage @packageArgs
+New-Item $installDir\notification_helper.exe.ignore -ItemType File -ErrorAction SilentlyContinue
+New-Item $installDir\chromedriver.exe.ignore -ItemType File -ErrorAction SilentlyContinue
+New-Item $installDir\nacl64.exe.ignore -ItemType File -ErrorAction SilentlyContinue
+New-Item $installDir\nwjc.exe.ignore -ItemType File -ErrorAction SilentlyContinue
+New-Item $installDir\payload.exe.ignore -ItemType File -ErrorAction SilentlyContinue
 
-# Create shim ignore file(s)
-Get-ChildItem -Path (Join-Path -Path $installDir -ChildPath '*.exe') | ForEach-Object {
-    New-Item -Name "$($_.Name).ignore" -Path $installDir -ItemType File -ErrorAction SilentlyContinue | Out-Null
-}
+Install-ChocolateyInstallPackage @packageArgs


### PR DESCRIPTION
On the Gitter package, you attempt to ignore additional files from getting shimmed. Unfortunately, shimming happens at the installation step, not after the script has finished. I solved this by manually placing the creating the files that are to be ignored. In the future, the Gitter updates may include more files to be ignored, but as of 5.0.1, this ignores all the unnecessary ones.