### PR TITLE
Close Syncthing before updating application

### DIFF
--- a/automatic/syncthing/tools/chocolateyBeforeModify.ps1
+++ b/automatic/syncthing/tools/chocolateyBeforeModify.ps1
@@ -1,18 +1,9 @@
-$processName = 'syncthing*'
-$process = Get-Process -Name $processName
-
-if ($process) {
-  Write-Host "Stopping Syncthing process..."
-  Stop-Process -InputObject $process
-
-  Start-Sleep -Seconds 3
-
-  $process = Get-Process -Name $processName
-  if ($process) {
-    Write-Warning "Killing Syncthing process..."
-    Stop-Process -InputObject $process -Force
+$process = Get-Process qbittorrent -ErrorAction SilentlyContinue
+if ($runningappl) {
+  $runningappl | Stop-Process
+  Sleep 5
+  if (!$runningappl.HasExited) {
+    $runningappl | Stop-Process
   }
-
-  Write-Warning "Syncthing will not be started after upgrading..."
 }
-pause
+Remove-Variable $process

--- a/automatic/syncthing/tools/chocolateyBeforeModify.ps1
+++ b/automatic/syncthing/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,18 @@
+$processName = 'syncthing*'
+$process = Get-Process -Name $processName
+
+if ($process) {
+  Write-Host "Stopping Syncthing process..."
+  Stop-Process -InputObject $process
+
+  Start-Sleep -Seconds 3
+
+  $process = Get-Process -Name $processName
+  if ($process) {
+    Write-Warning "Killing Syncthing process..."
+    Stop-Process -InputObject $process -Force
+  }
+
+  Write-Warning "Syncthing will not be started after upgrading..."
+}
+pause


### PR DESCRIPTION
Hi, this pull request adds a _chocolateybeforemodify.ps1_ file that kills, if not closes the Syncthing application before updating the application.