### PR TITLE
(teamviewer) add x64 support

### DIFF
--- a/automatic/teamviewer/tools/chocolateyInstall.ps1
+++ b/automatic/teamviewer/tools/chocolateyInstall.ps1
@@ -3,12 +3,15 @@
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   fileType      = 'EXE'
-  url           = 'https://download.teamviewer.com/download/TeamViewer_Setup.exe'
-
   softwareName  = 'TeamViewer*'
 
+  url           = 'https://download.teamviewer.com/download/TeamViewer_Setup.exe'
   checksum      = 'f60062cf21ed42ba0adf64a296f124074ef4ad92b6b58e2f488c4b028a286bf4'
   checksumType  = 'sha256'
+
+  url64         = 'https://download.teamviewer.com/download/TeamViewer_Setup_x64.exe'
+  checksum64    = 'efa1b635356ef73d7a61486ba89401b46cc7cf5a71f7d179beafe59152b2f8f6'
+  checksumType64= 'sha256'
 
   silentArgs    = "/S"
   validExitCodes= @(0)

--- a/automatic/teamviewer/update.ps1
+++ b/automatic/teamviewer/update.ps1
@@ -2,7 +2,8 @@
 
 . $PSScriptRoot\..\..\scripts\all.ps1
 
-$releases = 'https://download.teamviewer.com/download/TeamViewer_Setup.exe'
+$releasesx86 = 'https://download.teamviewer.com/download/TeamViewer_Setup.exe'
+$releasesx64 = 'https://download.teamviewer.com/download/TeamViewer_Setup_x64.exe'
 
 function global:au_SearchReplace {
     @{
@@ -10,6 +11,9 @@ function global:au_SearchReplace {
             '(^\s*url\s*=\s*)(''.*'')'          = "`$1'$($Latest.URL32)'"
             "(?i)(^\s*checksum\s*=\s*)('.*')"     = "`$1'$($Latest.Checksum32)'"
             "(?i)(^\s*checksumType\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType32)'"
+            '(^\s*url64\s*=\s*)(''.*'')'            = "`$1'$($Latest.URL64)'"
+            "(?i)(^\s*checksum64\s*=\s*)('.*')"     = "`$1'$($Latest.Checksum64)'"
+            "(?i)(^\s*checksumType64\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType64)'"
         }
     }
 }
@@ -20,15 +24,16 @@ function global:au_AfterUpdate {
 
 function global:au_GetLatest {
     $tempFile = New-TemporaryFile
-    Invoke-WebRequest -Uri $releases -OutFile $tempFile -UseBasicParsing
+    Invoke-WebRequest -Uri $releasesx86 -OutFile $tempFile -UseBasicParsing
     $fileVer = (Get-Item $tempfile).VersionInfo
     $versionForURL = "$($fileVer.ProductMajorPart)"
     $version = "$($fileVer.ProductMajorPart).$($fileVer.ProductMinorPart).$($fileVer.ProductBuildPart)"
 
     return @{
         URL32   = "https://download.teamviewer.com/download/version_$($versionForURL)x/TeamViewer_Setup.exe"
+        URL64   = "https://download.teamviewer.com/download/version_$($versionForURL)x/TeamViewer_Setup_x64.exe"
         Version = $version
     }
 }
 
-update -ChecksumFor 32
+update -ChecksumFor all


### PR DESCRIPTION
This should address https://github.com/pauby/ChocoPackages/issues/98.  I am also the author of the Disqus comment.

I tested via `choco pack` and the usual `choco install + uninstall` via the nupkg.  64-bit version was installed.  I do not have an 32-bit system to test on, but since all of this uses Chocolatey's native functions without any magic, I trust it still works on those.

You will need to fully test `update.ps1` yourself, as I'm not fully familiar with it.  I installed AU and the script seemed to do the right thing (despite complaining that `all.ps1` couldn't be found), but did state that the nuspec version is out-of-date + Choco repo already has 15.25.8.  I suspect there is something very different between our development environments, and since you're the package owner, I figure you'll know what's what.  I based the changes on your `onenote/update.ps1`.
