### PR TITLE
(streamdeck) Update endpoint for new releases detection

### DIFF
--- a/automatic/streamdeck/update.ps1
+++ b/automatic/streamdeck/update.ps1
@@ -28,8 +28,8 @@ function global:au_GetLatest {
   $update = Invoke-RestMethod -Uri $releases
 
   return @{
-    Url64   = $update.automatic.fileURL
-    Version = $update.automatic.version
+    Url64   = $update.manual.fileURL
+    Version = $update.manual.version
   }
 }
 

--- a/automatic/streamdeck/update.ps1
+++ b/automatic/streamdeck/update.ps1
@@ -15,8 +15,6 @@ function global:au_SearchReplace {
 
 
 function global:au_BeforeUpdate() {
-  $Latest.ChecksumType64 = 'SHA256'
-  $Latest.Checksum64 = Get-RemoteChecksum $Latest.Url64 -Algorithm $Latest.ChecksumType64
 }
 
 function global:au_AfterUpdate {
@@ -33,4 +31,4 @@ function global:au_GetLatest {
   }
 }
 
-Update-Package -ChecksumFor none
+Update-Package -ChecksumFor 64


### PR DESCRIPTION
## Description
Updated the URL and Version detection method to use "manual" results instead of "automatic".

## Motivation and Context
This change is required to detect the latest version of the software. The currently configured method is not pulling in the latest version when returning "automatic" results due to the .json being out of date.  However, when returning "manual" results, the latest version _is_ detected.  Elegato needs to correct the .json on their end in order to use "automatic" again.

## How Has This Been Tested?
Chocolatey Test Environment

## Screenshot (if appropriate, usually isn't needed):
![image](https://user-images.githubusercontent.com/12056704/177783687-67244f4e-11f4-4a86-9d5e-0a04903cfeb3.png)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository (if your change does not follow the style it will likely be rejected - this includes changes in formatting / layout).
- [ ] My change requires a change to the documentation (this usually means the notes in the description of a package) and I have updated the documentation accordingly.
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] The added / modified package passed install / uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
