### PR TITLE
(adobereader) Migrated package and updated to latest version

### DIFF
--- a/manual/adobereader/LICENSE
+++ b/manual/adobereader/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2021 Open Circle AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/manual/adobereader/README.md
+++ b/manual/adobereader/README.md
@@ -1,0 +1,45 @@
+# ![Adobe Acrobat Reader DC](https://cdn.jsdelivr.net/gh/pauby/ChocoPackages@fb3fc3a/icons/adobereader.png "Adobe Acrobat Reader DC Logo") [Adobe Acrobat Reader DC](https://chocolatey.org/packages/adobereader)
+
+Adobe Acrobat Reader DC software is the free, trusted global standard for viewing, printing, signing, sharing, and annotating PDFs. It's the only PDF viewer that can open and interact with all types of PDF content – including forms and multimedia. And now, it’s connected to Adobe Document Cloud – so you can work with PDFs on computers and mobile devices.
+
+This package installs/upgrades the Multi-lingual ("MUI") release. In some cases, this package will by default be able to install over the top of a language-specific installation. Otherwise, this package will exit and require either a manual uninstall of the language specific installation or having the parameter '/OverwriteInstallation' set to do this automatically.
+
+## Note
+
+If the package fails on Windows 8.1 or earlier, this might be due to the installation of kb2919355 (which is a dependency of this package) if your system is not up-to-date. This KB requires a reboot of the system before the adobereader package installs successfully.
+
+## Package installation defaults
+
+By default, **installation** of this package:
+
+- Will _NOT_ install a desktop icon.
+- Will _NOT_ install the Adobe Reader and Acrobat Manager ("ARM") service.
+- Will _NOT_ uninstall language-specific installations.
+- Will configure Reader to only **check for updates manually** with confirmation for install.
+
+However, **upgrades** to Adobe Reader via this package:
+
+- Will _NOT_ remove an existing desktop icon or add one when there isn't.
+- Will _NOT_ install the AdobeARM service.
+- Will _NOT_ remove the AdobeARM service (though it will disable it unless enabled by parameters).
+- Will _NOT_ re-enable updates (if disabled via package parameter)
+
+## Package Parameters
+
+- `/DesktopIcon` - The Desktop icon will be installed to the common desktop. (Install only.)
+- `/NoUpdates` - No updates via internal mechanisms (including manual checks). Only downloading from Adobe and running installers or updates (or updating this package) will advance the version of Reader. Once set, only uninstalling this package will remove this update block.
+- `/OverwriteInstallation` - Uninstall a language-specific installation before installing the Multi-lingual ("MUI") release. _Be aware that this will remove all data and features of an existing installation!_
+- `/EnableUpdateService` - Install the AdobeARM service. (Does not override `/NoUpdates`.)
+- `/UpdateMode:#` - Sets the update mode (below). (Does not override `/NoUpdates`.)
+
+### Update Modes
+
+- `0` - Manually check for and install updates. (Default and reset on every update)
+- `1` - Same as `0`.
+- `2` - Download updates for me, but let me choose when to install them. (Appears to be no different than `0`.)
+- `3` - Install updates automatically (via task scheduler or ARM service if enabled).
+- `4` - Notify me, but let me choose when to download and install updates.
+
+These parameters can be passed to the installer with the use of `-params`.
+For example :
+`choco install adobereader -params '"/DesktopIcon /UpdateMode:4"'`

--- a/manual/adobereader/adobereader.nuspec
+++ b/manual/adobereader/adobereader.nuspec
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. --><package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <!-- == PACKAGE SPECIFIC SECTION == -->
+    <id>adobereader</id>
+    <version>2023.003.20215</version>
+    <packageSourceUrl>https://github.com/pauby/chocopackages/tree/master/manual/adobereader</packageSourceUrl>
+    <owners>pauby, doc, sbaerlocher, ITIGO</owners>
+    <!-- == SOFTWARE SPECIFIC SECTION == -->
+    <title>Adobe Acrobat Reader DC</title>
+    <authors>Adobe</authors>
+    <projectUrl>https://www.adobe.com/products/reader.html</projectUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/pauby/ChocoPackages@fb3fc3a/icons/adobereader.png</iconUrl>
+    <copyright>Copyright © 1984-2023 Adobe Systems Incorporated and its licensors</copyright>
+    <licenseUrl>http://www.adobe.com/products/eulas/pdfs/Reader10_combined-20100625_1419.pdf</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <docsUrl>https://helpx.adobe.com/reader.html</docsUrl>
+    <tags>adobereader adobe acrobat reader DC pdf MUI multilanguage</tags>
+    <summary>View, print, sign, and annotate PDF files.</summary>
+    <description>
+This package installs/upgrades the Multi-lingual ("MUI") release. In some cases, this package will by default be able to install over the top of a language-specific installation. Otherwise, this package will exit and require either a manual uninstall of the language specific installation or having the parameter '/OverwriteInstallation' set to do this automatically.
+
+## Note
+
+If the package fails on Windows 8.1 or earlier, this might be due to the installation of kb2919355 (which is a dependency of this package) if your system is not up-to-date. This KB requires a reboot of the system before the adobereader package installs successfully.
+
+## Package installation defaults
+
+By default, **installation** of this package:
+
+- Will _NOT_ install a desktop icon.
+- Will _NOT_ install the Adobe Reader and Acrobat Manager ("ARM") service.
+- Will _NOT_ uninstall language-specific installations.
+- Will configure Reader to only **check for updates manually** with confirmation for install.
+
+However, **upgrades** to Adobe Reader via this package:
+
+- Will _NOT_ remove an existing desktop icon or add one when there isn't.
+- Will _NOT_ install the AdobeARM service.
+- Will _NOT_ remove the AdobeARM service (though it will disable it unless enabled by parameters).
+- Will _NOT_ re-enable updates (if disabled via package parameter)
+
+## Package Parameters
+
+- `/DesktopIcon` - The Desktop icon will be installed to the common desktop. (Install only.)
+- `/NoUpdates` - No updates via internal mechanisms (including manual checks). Only downloading from Adobe and running installers or updates (or updating this package) will advance the version of Reader. Once set, only uninstalling this package will remove this update block.
+- `/OverwriteInstallation` - Uninstall a language-specific installation before installing the Multi-lingual ("MUI") release. _Be aware that this will remove all data and features of an existing installation!_
+- `/EnableUpdateService` - Install the AdobeARM service. (Does not override `/NoUpdates`.)
+- `/UpdateMode:#` - Sets the update mode (below). (Does not override `/NoUpdates`.)
+
+### Update Modes
+
+- `0` - Manually check for and install updates. (Default and reset on every update)
+- `1` - Same as `0`.
+- `2` - Download updates for me, but let me choose when to install them. (Appears to be no different than `0`.)
+- `3` - Install updates automatically (via task scheduler or ARM service if enabled).
+- `4` - Notify me, but let me choose when to download and install updates.
+
+These parameters can be passed to the installer with the use of `-params`.
+For example :
+`choco install adobereader -params '"/DesktopIcon /UpdateMode:4"'`
+</description>
+    <releaseNotes>https://helpx.adobe.com/acrobat/release-note/release-notes-acrobat-reader.html</releaseNotes>
+    <dependencies>
+      <dependency id="kb2919355"/>
+    </dependencies>
+  </metadata>
+  <files>
+  <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/manual/adobereader/tools/chocolateyinstall.ps1
+++ b/manual/adobereader/tools/chocolateyinstall.ps1
@@ -16,7 +16,7 @@ $PerformNewInstall = $false
 $ApplyPatch = $false
 [array]$key = Get-UninstallRegistryKey -SoftwareName $DisplayName.replace(' Acrobat', ' Acrobat*')
 
-$MUImspURL -match 'AcroRdrDCUpd(\d+)_'
+$MUImspURL -match 'AcroRdrDCUpd(\d+)_' | Out-Null
 $UpdaterVersion = $Matches[1]
 
 $PackageParameters = Get-PackageParameters

--- a/manual/adobereader/tools/chocolateyinstall.ps1
+++ b/manual/adobereader/tools/chocolateyinstall.ps1
@@ -1,0 +1,247 @@
+$ErrorActionPreference = 'Stop'
+
+$DisplayName = 'Adobe Acrobat'
+
+$MUIurl = 'https://ardownload2.adobe.com/pub/adobe/reader/win/AcrobatDC/1500720033/AcroRdrDC1500720033_MUI.exe'
+$MUIurl64 = 'https://ardownload2.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2300120093/AcroRdrDCx642300120093_MUI.exe'
+$MUIchecksum = 'dfc4b3c70b7ecaeb40414c9d6591d8952131a5fffa0c0f5964324af7154f8111'
+$MUIchecksum64 = '69a3b05f4b90445024963af79b37520f26b289a8979894a5c9d8ef9c290c2ee4'
+$MUImspURL = 'https://ardownload2.adobe.com/pub/adobe/reader/win/AcrobatDC/2300320215/AcroRdrDCUpd2300320215_MUI.msp'
+$MUImspURL64 = 'https://ardownload2.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2300320215/AcroRdrDCx64Upd2300320215_MUI.msp'
+$MUImspChecksum = '79bfa391a86361a206557273eee8451d71ef9b3cdac5e611d6003d466e64c1ede39df2d2d65586fa0baef190837149cb17352fc8f3d38e5e5d165ff727cae1dc'
+$MUImspChecksum64 = '8df52e47f01c087eda818412ad973a7bf11b45f8dbba33231982c96dfcf47275ada9bb9ed1cccbe66a5a44c55f3ab0512ddb3a16b075c99c2e7d6334ebbea86b'
+
+$MUIinstalled = $false
+$PerformNewInstall = $false
+$ApplyPatch = $false
+[array]$key = Get-UninstallRegistryKey -SoftwareName $DisplayName.replace(' Acrobat', ' Acrobat*')
+
+$MUImspURL -match 'AcroRdrDCUpd(\d+)_'
+$UpdaterVersion = $Matches[1]
+
+$PackageParameters = Get-PackageParameters
+
+if ($key.Count -eq 1) {
+   $InstalledVersion = $key[0].DisplayVersion.replace('.', '')
+   $IsAdobeAcrobatReader = $key[0].DisplayName -match 'Adobe Acrobat Reader'
+   if ($IsAdobeAcrobatReader -and $key[0].DisplayName -notmatch 'MUI') {
+      if (($InstalledVersion -ge $UpdaterVersion) -and !($PackageParameters.OverwriteInstallation)) {
+         Write-Warning "The currently installed $($key[0].DisplayName) is a single-language install."
+         Write-Warning "You will need to uninstall $($key[0].DisplayName) first or use /OverwriteInstallation."
+         Throw 'Installation halted.'
+      }
+      elseif (($InstalledVersion -ge $UpdaterVersion) -and $PackageParameters.OverwriteInstallation) {
+         Write-Warning "The currently installed $($key[0].DisplayName) is a single-language install."
+         Write-Warning  'This package will replace it with the multi-language (MUI) release (Installation overwrite).'
+      }
+      else {
+         Write-Warning "The currently installed $($key[0].DisplayName) is a single-language install."
+         Write-Warning  'This package will replace it with the multi-language (MUI) release.'
+      }
+   }
+   else {
+      $MUIinstalled = $true
+      if ($InstalledVersion -eq $UpdaterVersion) {
+         Write-Verbose 'Currently installed version is the same as this package.  Nothing further to do.'
+         Return
+      }
+      elseif ($InstalledVersion -gt $UpdaterVersion) {
+         Write-Warning "$($key[0].DisplayName) v20$($key[0].DisplayVersion) installed."
+         Write-Warning "This package installs v$env:ChocolateyPackageVersion and cannot replace a newer version."
+         Throw 'Installation halted.'
+      }
+      else {
+         # for installations where there is an e.g. existing "Adobe Acrobat Reader DC MUI" present,
+         # we perform a new installation otherwise we apply the patch
+         if ($IsAdobeAcrobatReader) {
+            $PerformNewInstall = $true
+         }
+         else {
+            $ApplyPatch = $true
+         }
+      }
+   }
+}
+elseif ($key.count -gt 1) {
+   Write-Warning "$($key.Count) matching installs of Adobe Acrobat Reader DC found!"
+   Write-Warning 'To prevent accidental data loss, this install will be aborted.'
+   Write-Warning 'The following installs were found:'
+   $key | ForEach-Object { Write-Warning "- $($_.DisplayName)`t$($_.DisplayVersion)" }
+   Throw 'Installation halted.'
+}
+else {
+   $PerformNewInstall = $true
+}
+
+if ($PackageParameters.OverwriteInstallation) {
+   Write-Host 'Uninstalling single language version.'
+   $UninstallRegKey = [array](Get-UninstallRegistryKey "Adobe Acrobat Reader DC*")[0].UninstallString.split("/I")[2]
+   $MSIArgs = @(
+      "/x"
+      '"{0}"'
+      "/qn"
+   ) -f $UninstallRegKey
+   Start-Process "msiexec.exe" -ArgumentList $MSIArgs -Wait
+   $Uninstalled = $?
+   $RegPath = 'HKLM:\SOFTWARE\Policies\Adobe\Acrobat Reader\DC\FeatureLockDown'
+
+   if (Test-Path $RegPath) {
+      $key = Get-ItemProperty -path $RegPath
+      if ($key.bUpdater -ne $null) {
+         $null = Remove-ItemProperty -Path $RegPath -Name 'bUpdater' -Force
+      }
+   }
+
+   if ($Uninstalled) {
+      Write-Host "Successfully uninstalled existing Adobe Acrobat Reader."
+   }
+   else {
+      Throw "Failed to uninstall existing version of Adobe Acrobat Reader."
+   }
+}
+
+# Reference: https://www.adobe.com/devnet-docs/acrobatetk/tools/AdminGuide/properties.html#command-line-example
+$options = ' DISABLEDESKTOPSHORTCUT=1'
+if ($PackageParameters.DesktopIcon) {
+   $options = ''
+   Write-Host 'You requested a desktop icon.' -ForegroundColor Cyan
+}
+
+if ($PackageParameters.NoUpdates) {
+   $RegRoot = 'HKLM:\SOFTWARE\Policies'
+   $RegSubFolders = ('Adobe\Acrobat Reader\DC\FeatureLockDown').split('\')
+   for ($i = 0; $i -lt $RegSubFolders.count; $i++) {
+      $RegPath = "$RegRoot\$($RegSubFolders[0..$i] -join '\')"
+      if (-not (Test-Path $RegPath)) {
+         $null = New-Item -Path $RegPath.TrimEnd($RegSubFolders[$i]) -Name $RegSubFolders[$i]
+      }
+   }
+   $RegPath = "$RegRoot\$($RegSubFolders -join '\')"
+   if (Test-Path $RegPath) {
+      $null = New-ItemProperty -Path $RegPath -Name 'bUpdater' -PropertyType DWORD -Value 0 -Force
+   }
+   Write-Host 'You requested no Adobe updates.' -ForegroundColor Cyan
+}
+
+if ($PackageParameters.EnableUpdateService) {
+   Write-Host 'You requested to enable the auto-update service.' -ForegroundColor Cyan
+   if ($MUIinstalled) {
+      if (Get-Service -Name 'AdobeARMservice' -ErrorAction SilentlyContinue) {
+         $null = Set-Service -Name 'AdobeARMservice' -StartupType Automatic
+         $null = Start-Service -Name 'AdobeARMservice'
+      }
+      else {
+         Write-Warning 'The Adobe ARM update service is not available and is not installed on updates.'
+      }
+   }
+}
+else {
+   $options += ' DISABLE_ARM_SERVICE_INSTALL=1'
+   if (Get-Service -Name 'AdobeARMservice' -ErrorAction SilentlyContinue) {
+      $null = Stop-Service -Name 'AdobeARMservice' -Force
+      $null = Set-Service -Name 'AdobeARMservice' -StartupType Disabled
+   }
+}
+
+if (-not $PackageParameters.UpdateMode) {
+   $UpdateMode = 0
+}
+else { $UpdateMode = $PackageParameters.UpdateMode }
+
+if ((0..4) -contains $UpdateMode) {
+   Switch ($UpdateMode) {
+      0 { Write-Host 'Configuring manual update checks and installs.' -ForegroundColor Cyan }
+      1 { Write-Host 'You requested manual update checks and installs.' -ForegroundColor Cyan }
+      2 { Write-Host 'You requested automatic update downloads and manual installs.' -ForegroundColor Cyan }
+      3 { Write-Host 'You requested scheduled, automatic updates.' -ForegroundColor Cyan }
+      4 { Write-Host 'You requested notifications but manual updates.' -ForegroundColor Cyan }
+   }
+   if ($MUIinstalled) {
+      # This is the official setting based on the reference URL.
+      $RegPath1 = 'HKLM:\SOFTWARE\Adobe\Adobe ARM\1.0\ARM\'
+      if (Test-Path $RegPath1) {
+         $null = New-ItemProperty -Path $RegPath1 -Name 'iCheckReader' -Value $UpdateMode -force
+      }
+      $GUID = '{' + $key[0].UninstallString.split('{')[-1]
+      # This is the setting that actually causes a change in behavior.
+      $RegPath2 = "HKLM:\SOFTWARE\Wow6432Node\Adobe\Adobe ARM\Legacy\Reader\$GUID"
+      if (Test-Path $RegPath2) {
+         $null = New-ItemProperty -Path $RegPath2 -Name 'Mode' -Value $UpdateMode -force
+      }
+   }
+   else {
+      $options += " UPDATE_MODE=$UpdateMode"
+   }
+}
+
+$DownloadArgs = @{
+   packageName         = "$env:ChocolateyPackageName (update)"
+   FileFullPath        = Join-Path $env:TEMP "$env:ChocolateyPackageName.$env:ChocolateyPackageVersion.msp"
+   url                 = $MUImspURL
+   url64bit            = $MUImspURL64
+   checksum            = $MUImspChecksum
+   checksum64          = $MUImspChecksum64
+   checksumType        = 'SHA512'
+   GetOriginalFileName = $true
+}
+$mspPath = Get-ChocolateyWebFile @DownloadArgs
+
+if ($PerformNewInstall) {
+   $DownloadArgs = @{
+      packageName         = $env:ChocolateyPackageName
+      FileFullPath        = Join-Path $env:TEMP "$env:ChocolateyPackageName.$env:ChocolateyPackageVersion.installer.exe"
+      url                 = $MUIurl
+      url64bit            = $MUIurl64
+      checksum            = $MUIchecksum
+      checksumType64      = $MUIchecksum64
+      checksumType        = 'SHA256'
+      GetOriginalFileName = $true
+   }
+   $MUIexePath = Get-ChocolateyWebFile @DownloadArgs
+
+   $packageArgsEXE = @{
+      packageName    = "$env:ChocolateyPackageName (installer)"
+      fileType       = 'EXE'
+      File           = $MUIexePath
+      checksumType   = 'SHA256'
+      silentArgs     = "/sAll /msi /norestart /quiet PATCH=`"$mspPath`" ALLUSERS=1 EULA_ACCEPT=YES $options" +
+      " /L*v `"$env:TEMP\$env:chocolateyPackageName.$env:chocolateyPackageVersion.Install.log`""
+      validExitCodes = @(0, 1000, 1101, 1603)
+   }
+   $exitCode = Install-ChocolateyInstallPackage @packageArgsEXE
+
+   # check if the patch should be applied separately
+   [array]$key = Get-UninstallRegistryKey -SoftwareName $DisplayName.replace(' Acrobat', ' Acrobat*')
+   $InstalledVersion = $key[0].DisplayVersion.replace('.', '')
+   $ApplyPatch = $InstalledVersion -lt $UpdaterVersion
+
+   if ($exitCode -eq 1603) {
+      Write-Warning "For code 1603, Adobe recommends to 'shut down Microsoft Office and all web browsers' and try again."
+      Write-Warning 'The install log should provide more details about the encountered issue:'
+      Write-Warning "   $env:TEMP\$env:chocolateyPackageName.$env:chocolateyPackageVersion.Install.log"
+      Throw "Installation of $env:ChocolateyPackageName was unsuccessful."
+   }
+}
+
+if ($ApplyPatch) {
+   Write-Host 'Applying patch.'
+
+   $UpdateArgs = @{
+      Statements     = "/p `"$mspPath`" /norestart /quiet ALLUSERS=1 EULA_ACCEPT=YES $options" +
+      " /L*v `"$env:TEMP\$env:chocolateyPackageName.$env:chocolateyPackageVersion.Update.log`""
+      ExetoRun       = 'msiexec.exe'
+      validExitCodes = @(0, 1603)
+   }
+   $exitCode = Start-ChocolateyProcessAsAdmin @UpdateArgs
+
+   if ($exitCode -eq 1603) {
+      Write-Warning "For code 1603, Adobe recommends to 'shut down Microsoft Office and all web browsers' and try again."
+      Write-Warning 'The update log should provide more details about the encountered issue:'
+      Write-Warning "   $env:TEMP\$env:chocolateyPackageName.$env:chocolateyPackageVersion.Update.log"
+      Throw "Patching of $env:ChocolateyPackageName to the latest version was unsuccessful."
+   }
+}
+
+if ($PackageParameters.NoUpdates -or $UpdateMode -lt 2) {
+   Unregister-ScheduledTask 'Adobe Acrobat Update Task' -Confirm:$false -ErrorAction SilentlyContinue
+}

--- a/manual/adobereader/tools/chocolateyuninstall.ps1
+++ b/manual/adobereader/tools/chocolateyuninstall.ps1
@@ -1,0 +1,8 @@
+﻿$RegPath = 'HKLM:\SOFTWARE\Policies\Adobe\Acrobat Reader\DC\FeatureLockDown'
+
+if (Test-Path $RegPath) {
+   $key = Get-ItemProperty -path $RegPath
+   if ($key.bUpdater -ne $null) {
+      $null = Remove-ItemProperty -Path $RegPath -Name 'bUpdater' -Force
+   }
+}

--- a/manual/adobereader/update.ps1
+++ b/manual/adobereader/update.ps1
@@ -1,0 +1,63 @@
+import-module au
+
+function global:au_GetLatest {
+   # Discover the latest release version
+   $VersionURL  = 'https://helpx.adobe.com/acrobat/release-note/release-notes-acrobat-reader.html'
+   $download_page = Invoke-WebRequest -Uri $VersionURL #-UseBasicParsing -DisableKeepAlive
+   $ReleaseText = $download_page.links | 
+                     Where-Object {$_.innertext -match 'DC.*\([0-9.]+\)'} |
+                     Select-Object -ExpandProperty innertext -First 1
+   $Release = $ReleaseText -replace '.*\(([0-9.]+)\).*','$1'
+   $version = "20$Release"
+   $ReleaseFolder = $Release.replace('.','')
+
+   # Find the MSP for the latest version
+   $FTPbase = 'ftp://ftp.adobe.com/pub/adobe/reader/win/AcrobatDC'
+   $MSPpage = Invoke-WebRequest -Uri "$FTPbase/$ReleaseFolder" -UseBasicParsing -DisableKeepAlive
+   $MUIMSPstub = $MSPpage.rawcontent -split '"' |
+                  Where-Object {$_ -match 'MUI\.msp$'} |
+                  Select-Object -First 1
+   $MSPstub = $MSPpage.rawcontent -split '"' |
+                  Where-Object {$_ -match '\d\.msp$'} |
+                  Select-Object -First 1
+
+   # Find the most-recent EXE
+   $FTPpage = Invoke-WebRequest -Uri $FTPbase -UseBasicParsing -DisableKeepAlive
+   $Folders = $FTPpage.rawcontent -split '[\r\n]' | 
+                  Where-Object {$_ -match '>\d+<'} |
+                  ForEach-Object {$_ -replace '.*>(\d+)<.*','$1'} |
+                  Sort-Object -Descending
+   foreach ($folder in $Folders) {
+      $FolderFiles = Invoke-WebRequest -Uri "$FTPbase/$folder" -UseBasicParsing -DisableKeepAlive
+      $EXEstub = $FolderFiles.rawcontent -split '"' |
+                     Where-Object {$_ -match 'en_US\.exe$'} |
+                     Select-Object -First 1
+      if ($EXEstub) { break }
+   }
+   $MUIstub = $EXEstub -replace 'en_US','MUI'
+
+   return  @{ 
+       Version   = $version
+       URL32     = "http://ardownload.adobe.com/pub/adobe/reader/win/AcrobatDC/$MUIstub"
+       MUIMSPurl = "$FTPbase/$MUIMSPstub"
+   }
+}
+
+function global:au_SearchReplace {
+   @{
+      'tools\chocolateyInstall.ps1' = @{
+         "(^[$]MUIurl\s*=\s*)('.*')"         = "`$1'$($Latest.URL32)'"
+         "(^[$]MUIchecksum\s*=\s*)('.*')"    = "`$1'$($Latest.Checksum32)'"
+         "(^[$]MUImspURL\s*=\s*)('.*')"      = "`$1'$($Latest.MUIMSPurl)'"
+         "(^[$]MUImspChecksum\s*=\s*)('.*')" = "`$1'$($Latest.MUImspChecksum)'"
+      } 
+   }
+}
+
+function global:au_BeforeUpdate() {
+   $Latest.MUImspChecksum = Get-RemoteChecksum $Latest.MUIMSPurl
+}
+
+Update-Package -NoCheckChocoVersion
+
+


### PR DESCRIPTION
## Description
Migrated the package from https://github.com/open-circle-ltd/chocolatey.adobe-acrobat-reader-dc to here and updated it.

## Motivation and Context
The package was outdated and broken. [This PR](https://github.com/open-circle-ltd/chocolatey.adobe-acrobat-reader-dc/pull/37) fixed the package, but it was unfortunately not merged. See comments [here](https://github.com/open-circle-ltd/chocolatey.adobe-acrobat-reader-dc/pull/37#issuecomment-1607511636), [here](https://github.com/open-circle-ltd/chocolatey.adobe-acrobat-reader-dc/pull/37#issuecomment-1609300438), and [here](https://github.com/open-circle-ltd/chocolatey.adobe-acrobat-reader-dc/pull/37#issuecomment-1612828310).

## How Has this Been Tested?
Installed in Chocolatey Test Environment with Chocolatey CLI version 1.4.0 and 2.1.0.

## Screenshot (if appropriate, usually isn't needed):

This confirms the package installs successfully (on Windows Server 2019):

![image](https://github.com/pauby/ChocoPackages/assets/12760779/9426d2bc-0995-4451-a05f-146e38f85e41)

This confirms the correct version of the software is installed.

![image](https://github.com/pauby/ChocoPackages/assets/12760779/6f48da0c-4937-460c-8782-84ae5cb598f3)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this repository (if your change does not follow the style it will likely be rejected - this includes changes in formatting / layout).
- [x] My change requires a change to the documentation (this usually means the notes in the description of a package) and I have updated the documentation accordingly.
- [x] I have updated the package description and it is less than 4000 characters.
- [x] The added / modified package passed install / uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
