### PR TITLE
(dbatools, dbatools-library.powershell) Fixes Missing Dependency

### DIFF
--- a/automatic/dbatools-library.powershell/README.md
+++ b/automatic/dbatools-library.powershell/README.md
@@ -1,0 +1,9 @@
+# ![dbatools Logo](https://cdn.jsdelivr.net/gh/pauby/ChocoPackages@306a1af5/icons/dbatools.png "dbatools")[dbatools](https://chocolatey.org/packages/dbatools-library.powershell)
+
+dbatools is sort of like a command-line SQL Server Management Studio. The project initially started out as Start-SqlMigration.ps1, but has now grown into a collection of over 600 commands that help automate SQL Server tasks and encourage best practices.
+
+This module is the library enabling cross-platform usage of the dbatools module.
+
+_**NOTE: This module requires a minimum of PowerShell v3.**_
+
+**NOTE**: This is an automatically updated package. If you find it is out of date by more than a week, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/dbatools-library.powershell/dbatools-library.powershell.nuspec
+++ b/automatic/dbatools-library.powershell/dbatools-library.powershell.nuspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Read this before creating packages: https://chocolatey.org/docs/create-packages -->
+<!-- It is especially important to read the above link to understand additional requirements when publishing packages to the community feed aka dot org (https://chocolatey.org/packages). -->
+<!-- Test your packages in a test environment: https://github.com/chocolatey/chocolatey-test-environment -->
+<!-- 
+This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Reference. Chocolatey 
+uses a special version of NuGet.Core that allows us to do more than was initially possible. As such 
+there are certain things to be aware of:
+* the package xmlns schema url may cause issues with nuget.exe
+* Any of the following elements can ONLY be used by choco tools - projectSourceUrl, docsUrl, mailingListUrl, bugTrackerUrl, packageSourceUrl, provides, conflicts, replaces
+* nuget.exe can still install packages with those elements but they are ignored. Any authoring tools or commands will error on those elements
+--> 
+<!-- You can embed software files directly into packages, as long as you are not bound by distribution rights. -->
+<!-- * If you are an organization making private packages, you probably have no issues here -->
+<!-- * If you are releasing to the community feed, you need to consider distribution rights. -->
+<!-- Do not remove this test for UTF-8: if appear as greek uppercase omega letter enclosed in
+quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+    <metadata>
+        <!-- == PACKAGE SPECIFIC SECTION == -->
+        <!-- This section is about this package, although id and version have ties back to the software -->
+        <!-- id is lowercase and if you want a good separator for words, use '-', not '.'. Dots are only acceptable as suffixes for certain types of packages, e.g. .install, .portable, .extension, .template -->
+        <!-- If the software is cross-platform, attempt to use the same id as the debian/rpm package(s) if possible. -->
+        <id>dbatools-library.powershell</id>
+        <version>2023.9.21</version>
+        <packageSourceUrl>https://github.com/pauby/ChocoPackages/tree/master/automatic/dbatools-library.powershell</packageSourceUrl>
+        <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
+        <owners>pauby jpruskin</owners>
+        <!-- ============================== -->
+        <!-- == SOFTWARE SPECIFIC SECTION == -->
+        <!-- This section is about the software itself -->
+        <title>dbatools.library (PowerShell Module)</title>
+        <authors>the dbatools team</authors>
+        <!-- projectUrl is required for the community feed -->
+        <projectUrl>https://dbatools.io</projectUrl>
+        <iconUrl>https://cdn.jsdelivr.net/gh/pauby/ChocoPackages@306a1af5/icons/dbatools.png</iconUrl>
+        <copyright>2022 Data Platform Community</copyright>
+        <!-- If there is a license Url available, it is is required for the community feed -->
+        <licenseUrl>https://github.com/dataplat/dbatools/blob/master/license</licenseUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <projectSourceUrl>https://github.com/dataplat/dbatools.library</projectSourceUrl>
+        <docsUrl>https://docs.dbatools.io/</docsUrl>
+        <!-- <mailingListUrl>https://sourceforge.net/p/keepass/discussion/</mailingListUrl> -->
+        <bugTrackerUrl>https://github.com/dataplat/dbatools.library/issues</bugTrackerUrl>
+        <tags>admin powershell module template dba sqlserver migrations sql dba databases mac linux core smo</tags>
+        <summary>The library that powers dbatools, the community module for SQL Server Pros.</summary>
+        <description>dbatools is sort of like a command-line SQL Server Management Studio. The project initially started out as Start-SqlMigration.ps1, but has now grown into a collection of over 600 commands that help automate SQL Server tasks and encourage best practices.
+
+This module is the library enabling cross-platform usage of the dbatools module.
+
+_**NOTE: This module requires a minimum of PowerShell v3.**_
+
+**NOTE**: This is an automatically updated package. If you find it is out of date by more than a week, please contact the maintainer(s) and let them know the package is no longer updating correctly.
+</description>
+        <releaseNotes>https://github.com/dataplat/dbatools.library/releases</releaseNotes>
+        <!-- =============================== -->
+        <!-- Specifying dependencies and version ranges? https://docs.nuget.org/create/versioning#specifying-version-ranges-in-.nuspec-files -->
+            <!-- <dependencies> -->
+                <!-- <dependency id="" version="" /> -->
+                <!-- <dependency id="" version="[_MIN_VERSION_INCLUSIVE, MAX_VERSION_INCLUSIVE]" /> -->
+                <!-- <dependency id="" version="[_MIN_VERSION_INCLUSIVE, MAX_VERSION_EXCLUSIVE)" /> -->
+                <!-- <dependency id="" /> -->
+                <!-- <dependency id="chocolatey-uninstall.extension" /> -->
+            <!-- </dependencies> -->
+        <!-- chocolatey-uninstall.extension - If supporting 0.9.9.x (or below) and including a chocolateyUninstall.ps1 file to uninstall an EXE/MSI, you probably want to include chocolatey-uninstall.extension as a dependency. Please verify whether you are using a helper function from that package. -->
+        <!--<provides>NOT YET IMPLEMENTED</provides>-->
+        <!--<conflicts>NOT YET IMPLEMENTED</conflicts>-->
+        <!--<replaces>NOT YET IMPLEMENTED</replaces>-->
+    </metadata>
+    <files>
+        <!-- this section controls what actually gets packaged into the Chocolatey package -->
+        <file src="tools\**" target="tools" />
+        <!--Building from Linux? You may need this instead: <file src="tools/**" target="tools" />-->
+    </files>
+</package>

--- a/automatic/dbatools-library.powershell/tools/LICENSE.txt
+++ b/automatic/dbatools-library.powershell/tools/LICENSE.txt
@@ -1,0 +1,25 @@
+From: https://raw.githubusercontent.com/dataplat/dbatools.library/main/LICENSE
+
+LICENSE
+
+MIT License
+
+Copyright (c) 2022 Data Platform Community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/automatic/dbatools-library.powershell/tools/VERIFICATION.txt
+++ b/automatic/dbatools-library.powershell/tools/VERIFICATION.txt
@@ -1,0 +1,14 @@
+VERIFICATION
+Verification is intended to assist the Chocolatey moderators and community in verifying that this package's contents are trustworthy.
+
+To verify the files using the project source:
+
+1. Please go to the project source location (https://github.com/dataplat/dbatools.library) and download the source files;
+2. Build the source to create the binary files to verify;
+3. Use Get-FileHash -Path <FILE TO VERIFY> to get the file hash value from both the built file (from step 1 above) and the file from the dbatools.zip within the package and compare them;
+
+Alternatively you can download the module from the PowerShell Gallery ...
+
+    Save-Module -Name dbatools -Path <PATH TO DOWNLOAD TO>
+
+... and compare the files from the package against those in the installed module. Again use Get-FileHash -Path <FILE TO VERIFY> to retrieve those hash values.

--- a/automatic/dbatools-library.powershell/tools/chocolateyBeforeModify.ps1
+++ b/automatic/dbatools-library.powershell/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,21 @@
+$ErrorActionPreference = 'Stop'
+
+$moduleName = 'dbatools.library'      # this could be different from package name
+
+$module = Get-Module -Name $moduleName
+if ($module) {
+    Write-Verbose "Module '$moduleName' is imported into the session. Removing it."
+    Remove-Module -Name $moduleName -Force -ErrorAction SilentlyContinue
+
+    if ($lib = [appdomain]::CurrentDomain.GetAssemblies() | Where-Object FullName -like "dbatools, *") {
+        Write-Verbose "Found locked DLL files for module '$moduleName'."
+        $moduleDir = Split-Path $module.Path -Parent
+        if ($lib.Location -like "$moduleDir\*") {
+            Write-Warning @"
+We have detected dbatools to be already imported from '$moduleDir' and the dll files have been locked and cannot be updated.
+Please close all consoles that have dbatools imported (Remove-Module dbatools is NOT enough).
+"@
+            throw 
+        }
+    }
+}

--- a/automatic/dbatools-library.powershell/tools/chocolateyInstall.ps1
+++ b/automatic/dbatools-library.powershell/tools/chocolateyInstall.ps1
@@ -2,6 +2,7 @@
 
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $moduleName = 'dbatools.library'  # this may be different from the package name and different case
+$moduleVersion = $env:ChocolateyPackageVersion
 
 if ($PSVersionTable.PSVersion.Major -lt 3) {
     throw "$moduleName) module requires a minimum of PowerShell v3."
@@ -15,7 +16,7 @@ $destPath   = Join-Path -Path $env:ProgramFiles -ChildPath "WindowsPowerShell\Mo
 
 if ($PSVersionTable.PSVersion.Major -ge 5)
 {
-    $destPath     = Join-Path -Path $destPath -ChildPath $env:ChocolateyPackageVersion
+    $destPath     = Join-Path -Path $destPath -ChildPath $moduleVersion
 }
 
 Write-Verbose "Creating destination directory '$destPath' for module."

--- a/automatic/dbatools-library.powershell/tools/chocolateyInstall.ps1
+++ b/automatic/dbatools-library.powershell/tools/chocolateyInstall.ps1
@@ -1,0 +1,38 @@
+﻿$ErrorActionPreference = 'Stop'
+
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$moduleName = 'dbatools.library'  # this may be different from the package name and different case
+
+if ($PSVersionTable.PSVersion.Major -lt 3) {
+    throw "$moduleName) module requires a minimum of PowerShell v3."
+}
+
+# module may already be installed outside of Chocolatey
+Remove-Module -Name $moduleName -Force -ErrorAction SilentlyContinue
+
+$sourcePath = Join-Path -Path $toolsDir -ChildPath "$modulename.zip"
+$destPath   = Join-Path -Path $env:ProgramFiles -ChildPath "WindowsPowerShell\Modules\$moduleName"
+
+if ($PSVersionTable.PSVersion.Major -ge 5)
+{
+    $destPath     = Join-Path -Path $destPath -ChildPath $env:ChocolateyPackageVersion
+}
+
+Write-Verbose "Creating destination directory '$destPath' for module."
+New-Item -Path $destPath -ItemType Directory -Force -ErrorAction SilentlyContinue | Out-Null
+
+Write-Verbose "Extracting '$moduleName' files from '$sourcePath' to '$destPath'."
+Get-ChocolateyUnzip -FileFullPath $sourcePath -Destination $destPath
+
+if ($PSVersionTable.PSVersion.Major -lt 4)
+{
+    $modulePaths = [Environment]::GetEnvironmentVariable('PSModulePath', 'Machine') -split ';'
+    if ($modulePaths -notcontains $destPath)
+    {
+        Write-Verbose "Adding '$destPath' to PSModulePath."
+        $newModulePath = @($destPath, $modulePaths) -join ';'
+
+        [Environment]::SetEnvironmentVariable('PSModulePath', $newModulePath, 'Machine')
+        $env:PSModulePath = $newModulePath
+    }
+}

--- a/automatic/dbatools-library.powershell/tools/chocolateyUninstall.ps1
+++ b/automatic/dbatools-library.powershell/tools/chocolateyUninstall.ps1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = 'Stop'
+
+$moduleName = 'dbatools.library'
+$sourcePath = Join-Path -Path $env:ProgramFiles -ChildPath "WindowsPowerShell\Modules\$moduleName"
+
+Write-Verbose "Removing all version of '$moduleName' from '$sourcePath'."
+Remove-Item -Path $sourcePath -Recurse -Force -ErrorAction SilentlyContinue
+
+if ($PSVersionTable.PSVersion.Major -lt 4) {
+    $modulePaths = [Environment]::GetEnvironmentVariable('PSModulePath', 'Machine') -split ';'
+
+    Write-Verbose "Removing '$sourcePath' from PSModulePath."
+    $newModulePath = $modulePaths | Where-Object { $_ -ne $sourcePath }
+
+    [Environment]::SetEnvironmentVariable('PSModulePath', $newModulePath, 'Machine')
+    $env:PSModulePath = $newModulePath
+}

--- a/automatic/dbatools-library.powershell/update.ps1
+++ b/automatic/dbatools-library.powershell/update.ps1
@@ -1,0 +1,46 @@
+#import-module au
+
+. $PSScriptRoot\..\..\scripts\all.ps1
+
+$moduleName  = 'dbatools.library'
+
+function global:au_SearchReplace {
+    @{
+    }
+}
+
+function global:au_BeforeUpdate() {
+    do {
+        $tempPath = Join-Path -Path $env:TEMP -ChildPath ([GUID]::NewGuid()).ToString()
+    }
+    while (Test-Path $tempPath)
+
+    New-Item -Path $tempPath -ItemType Directory | Out-Null
+    Save-Module -Name $moduleName -RequiredVersion $Latest.ModuleVersion -Path $tempPath
+    $modulePath = Join-Path -Path $tempPath -ChildPath "\$ModuleName\$($Latest.ModuleVersion)\"
+
+    $zipPath = Join-Path -Path $tempPath -ChildPath "$moduleName.zip"
+    Compress-Archive -Path (Join-Path -Path $modulePath -ChildPath "*") -DestinationPath $zipPath -CompressionLevel Optimal
+
+    $params = @{
+        Path        = $zipPath
+        Destination = "tools\"
+        Force       = $true
+    }
+    Move-Item @params
+}
+
+function global:au_AfterUpdate {
+    Set-DescriptionFromReadme -SkipFirst 2
+}
+
+function global:au_GetLatest {
+    $version = (Find-Module -Name $moduleName).Version.ToString()
+
+    return @{
+        Version       = $version
+        ModuleVersion = $version
+    }
+}
+
+update -ChecksumFor none

--- a/automatic/dbatools-library.powershell/update.ps1
+++ b/automatic/dbatools-library.powershell/update.ps1
@@ -6,6 +6,18 @@ $moduleName  = 'dbatools.library'
 
 function global:au_SearchReplace {
     @{
+        "tools\chocolateyInstall.ps1" = @{
+            # We use ChocolateyPackageVersion to minimise changes to the package code -
+            # If using a patchfix version, use the moduleversion instead of the packageversion.
+            '(\s*\$moduleVersion\s*=\s*)(\$env:ChocolateyPackageVersion|(["'']?).+["'']?)' = "`${1}$(
+                if ($Latest.ModuleVersion -ne $Latest.Version) {
+                    $Quote = if ($Matches.'3') {'${3}'} else {"'"}
+                    $Quote + $Latest.ModuleVersion + $Quote
+                } else {
+                    '$env:ChocolateyPackageVersion'
+                }
+            )"
+        }
     }
 }
 

--- a/automatic/dbatools/README.md
+++ b/automatic/dbatools/README.md
@@ -1,6 +1,6 @@
 # ![dbatools Logo](https://cdn.jsdelivr.net/gh/pauby/ChocoPackages@306a1af5/icons/dbatools.png "dbatools")[dbatools](https://chocolatey.org/packages/dbatools)
 
-dbatools is sort of like a command-line SQL Server Management Studio. The project initially started out as Start-SqlMigration.ps1, but has now grown into a collection of over 300 commands that help automate SQL Server tasks and encourage best practices.
+dbatools is sort of like a command-line SQL Server Management Studio. The project initially started out as Start-SqlMigration.ps1, but has now grown into a collection of over 600 commands that help automate SQL Server tasks and encourage best practices.
 
 _**NOTE: This module requires a minimum of PowerShell v3.**_
 

--- a/automatic/dbatools/dbatools.nuspec
+++ b/automatic/dbatools/dbatools.nuspec
@@ -3,11 +3,12 @@
 <!-- It is especially important to read the above link to understand additional requirements when publishing packages to the community feed aka dot org (https://chocolatey.org/packages). -->
 <!-- Test your packages in a test environment: https://github.com/chocolatey/chocolatey-test-environment -->
 <!--
-This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Reference. Chocolatey uses a special version of NuGet.Core that allows us to do more than was initially possible. As such there are certain things to be aware of:
-
+This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Reference. Chocolatey
+uses a special version of NuGet.Core that allows us to do more than was initially possible. As such
+there are certain things to be aware of:
 * the package xmlns schema url may cause issues with nuget.exe
 * Any of the following elements can ONLY be used by choco tools - projectSourceUrl, docsUrl, mailingListUrl, bugTrackerUrl, packageSourceUrl, provides, conflicts, replaces
-* nuget.exe can still install packages with those elements but they are ignored. Any authoring tools or commands will error on those elements
+* nuget.exe can still install packages with those elements but they are ignored. Any authoring tools or commands will error on those elements 
 -->
 <!-- You can embed software files directly into packages, as long as you are not bound by distribution rights. -->
 <!-- * If you are an organization making private packages, you probably have no issues here -->
@@ -20,10 +21,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
         <!-- id is lowercase and if you want a good separator for words, use '-', not '.'. Dots are only acceptable as suffixes for certain types of packages, e.g. .install, .portable, .extension, .template -->
         <!-- If the software is cross-platform, attempt to use the same id as the debian/rpm package(s) if possible. -->
         <id>dbatools</id>
-        <!-- version should MATCH as closely as possible with the underlying software -->
-        <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
-        <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-        <version>0.9.362</version>
+        <version>2.0.4</version>
         <packageSourceUrl>https://github.com/pauby/ChocoPackages/tree/master/automatic/dbatools</packageSourceUrl>
         <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
         <owners>pauby</owners>
@@ -44,8 +42,8 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
         <!-- <mailingListUrl>https://sourceforge.net/p/keepass/discussion/</mailingListUrl> -->
         <bugTrackerUrl>https://github.com/sqlcollaborative/dbatools/issues</bugTrackerUrl>
         <tags>admin powershell module template dba sqlserver sql tools database</tags>
-        <summary>dbatools is sort of like a command-line SQL Server Management Studio. </summary>
-        <description>dbatools logo dbatools is sort of like a command-line SQL Server Management Studio. The project initially started out as Start-SqlMigration.ps1, but has now grown into a collection of over 300 commands that help automate SQL Server tasks and encourage best practices.
+        <summary>dbatools is sort of like a command-line SQL Server Management Studio.</summary>
+        <description>dbatools is sort of like a command-line SQL Server Management Studio. The project initially started out as Start-SqlMigration.ps1, but has now grown into a collection of over 600 commands that help automate SQL Server tasks and encourage best practices.
 
 _**NOTE: This module requires a minimum of PowerShell v3.**_
 
@@ -54,17 +52,20 @@ _**NOTE: This module requires a minimum of PowerShell v3.**_
         <releaseNotes>https://github.com/sqlcollaborative/dbatools/releases</releaseNotes>
         <!-- =============================== -->
         <!-- Specifying dependencies and version ranges? https://docs.nuget.org/create/versioning#specifying-version-ranges-in-.nuspec-files -->
-        <!-- <dependencies> -->
-            <!-- <dependency id="" version="" /> -->
-            <!-- <dependency id="" version="[_MIN_VERSION_INCLUSIVE, MAX_VERSION_INCLUSIVE]" /> -->
-            <!-- <dependency id="" version="[_MIN_VERSION_INCLUSIVE, MAX_VERSION_EXCLUSIVE)" /> -->
-            <!-- <dependency id="" /> -->
-            <!-- <dependency id="chocolatey-uninstall.extension" /> -->
-        <!-- </dependencies> -->
+            <!-- <dependencies> -->
+                <!-- <dependency id="" version="" /> -->
+                <!-- <dependency id="" version="[_MIN_VERSION_INCLUSIVE, MAX_VERSION_INCLUSIVE]" /> -->
+                <!-- <dependency id="" version="[_MIN_VERSION_INCLUSIVE, MAX_VERSION_EXCLUSIVE)" /> -->
+                <!-- <dependency id="" /> -->
+                <!-- <dependency id="chocolatey-uninstall.extension" /> -->
+            <!-- </dependencies> -->
         <!-- chocolatey-uninstall.extension - If supporting 0.9.9.x (or below) and including a chocolateyUninstall.ps1 file to uninstall an EXE/MSI, you probably want to include chocolatey-uninstall.extension as a dependency. Please verify whether you are using a helper function from that package. -->
         <!--<provides>NOT YET IMPLEMENTED</provides>-->
         <!--<conflicts>NOT YET IMPLEMENTED</conflicts>-->
         <!--<replaces>NOT YET IMPLEMENTED</replaces>-->
+        <dependencies>
+            <dependency id="dbatools-library.powershell" version="2023.5.5" />
+        </dependencies>
     </metadata>
     <files>
         <!-- this section controls what actually gets packaged into the Chocolatey package -->

--- a/automatic/dbatools/tools/chocolateyInstall.ps1
+++ b/automatic/dbatools/tools/chocolateyInstall.ps1
@@ -2,6 +2,7 @@
 
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $moduleName = 'dbatools'  # this may be different from the package name and different case
+$moduleVersion = $env:ChocolateyPackageVersion
 
 if ($PSVersionTable.PSVersion.Major -lt 3) {
     throw "$moduleName) module requires a minimum of PowerShell v3."
@@ -15,7 +16,7 @@ $destPath   = Join-Path -Path $env:ProgramFiles -ChildPath "WindowsPowerShell\Mo
 
 if ($PSVersionTable.PSVersion.Major -ge 5)
 {
-    $destPath     = Join-Path -Path $destPath -ChildPath $env:ChocolateyPackageVersion
+    $destPath     = Join-Path -Path $destPath -ChildPath $moduleVersion
 }
 
 Write-Verbose "Creating destination directory '$destPath' for module."

--- a/automatic/dbatools/update.ps1
+++ b/automatic/dbatools/update.ps1
@@ -6,6 +6,9 @@ $moduleName  = 'dbatools'
 
 function global:au_SearchReplace {
     @{
+        "dbatools.nuspec" = @{
+            '(\s+<dependency\s+id="dbatools-library\.powershell" version=)"([\.\d]+)" />' = "`$1`"$($Latest.LibVersion)`" />"
+        }
     }
 }
 
@@ -37,11 +40,13 @@ function global:au_AfterUpdate {
 }
 
 function global:au_GetLatest {
-    $version = (Find-Module -Name $moduleName).Version.ToString()
+    $module = Find-Module -Name $moduleName
+    $version = $module.Version.ToString()
 
     return @{
         Version       = $version
         ModuleVersion = $version
+        LibVersion    = $module.Dependencies.Where{$_.Name -eq 'dbatools.library'}.MinimumVersion
     }
 }
 

--- a/automatic/dbatools/update.ps1
+++ b/automatic/dbatools/update.ps1
@@ -9,6 +9,18 @@ function global:au_SearchReplace {
         "dbatools.nuspec" = @{
             '(\s+<dependency\s+id="dbatools-library\.powershell" version=)"([\.\d]+)" />' = "`$1`"$($Latest.LibVersion)`" />"
         }
+        "tools\chocolateyInstall.ps1" = @{
+            # We use ChocolateyPackageVersion to minimise changes to the package code -
+            # If using a patchfix version, use the moduleversion instead of the packageversion.
+            '(\s*\$moduleVersion\s*=\s*)(\$env:ChocolateyPackageVersion|(["'']?).+["'']?)' = "`${1}$(
+                if ($Latest.ModuleVersion -ne $Latest.Version) {
+                    $Quote = if ($Matches.'3') {'${3}'} else {"'"}
+                    $Quote + $Latest.ModuleVersion + $Quote
+                } else {
+                    '$env:ChocolateyPackageVersion'
+                }
+            )"
+        }
     }
 }
 


### PR DESCRIPTION
## Description
Adds the `dbatools-library.powershell` package, updates `dbatools` to have a dependency on it.

Additionally, fixes module installation when a package is using [package fix version notation](https://docs.chocolatey.org/en-us/create/create-packages#package-fix-version-notation), as importing the module would fail when it installed using the package version.

## Motivation and Context
DbaTools was missing the required DbaTools.Library module. This fixes the install so that it will import correctly!

## How Has this Been Tested?
- Tested on Windows 10 Sandbox

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~

## Checklist:
- [x] My code follows the code style of this repository (if your change does not follow the style it will likely be rejected - this includes changes in formatting / layout).
- ~[ ] My change requires a change to the documentation (this usually means the notes in the description of a package) and I have updated the documentation accordingly.~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] The added / modified package passed install / uninstall in the chocolatey test environment.
- ~[ ] The changes only affect a single package (not including meta package).~
