### PR TITLE
automatic/emacs.portable Modify chocolateyInstall.ps1 and Update Package

### DIFF
--- a/automatic/emacs.portable/emacs.portable.nuspec
+++ b/automatic/emacs.portable/emacs.portable.nuspec
@@ -23,7 +23,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>28.1</version>
+    <version>29.1.0.20231123</version>
     <packageSourceUrl>https://github.com/pauby/chocopackages/tree/master/automatic/emacs.portable</packageSourceUrl>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <owners>pauby</owners>
@@ -60,7 +60,7 @@ The features of GNU Emacs include:
   * A wide range of functionality beyond text editing, including a project planner, mail and news reader, debugger interface, calendar, IRC client, and more.
   * A packaging system for downloading and installing extensions.
 
-**NOTE**: This is the `.portable` version of Emacs. Unlike previous versions this will unpack the files to the `$env:ChocolateyToolsLocation` folder.
+**NOTE**: This is the `.portable` version of Emacs. Unlike previous versions this will unpack the files to the `$env:ChocolateyToolsLocation\emacs` folder (usually c:\tools\emacs).
 
 **NOTE**: This is an automatically updated package. If you find it is out of date by more than a week, please contact the maintainer(s) and let them know the package is no longer updating correctly.
 </description>

--- a/automatic/emacs.portable/tools/VERIFICATION.txt
+++ b/automatic/emacs.portable/tools/VERIFICATION.txt
@@ -1,4 +1,4 @@
-﻿VERIFICATION
+VERIFICATION
 
 Verification is intended to assist the Chocolatey moderators and community in verifying that this package's contents are trustworthy.
 
@@ -6,6 +6,6 @@ To verify the files using the project source:
 
 1. Download the binary from the URL below and verify its checksum using Get-FileHash and compare it to the details below.
 
-x64 URL: https://ftp.gnu.org/gnu/emacs/windows/emacs-28/emacs-28.1.zip
-x64 Checksum Type: SHA256
-x64 Checksum: 0EF568DF955FEC4721634336585968FE593F3B008FCE936A464FB524E5A3F009
+x64 URL: https://ftp.gnu.org/gnu/emacs/windows/emacs-29/emacs-29.1.zip
+x64 Checksum Type: sha256
+x64 Checksum: 8BF7F8921089A53F1C5686698F8155131E6B70790735C1663A7CDD1E172F72EA

--- a/automatic/emacs.portable/tools/chocolateyInstall.ps1
+++ b/automatic/emacs.portable/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-$softwareVersion = '28.1'
+$softwareVersion = '29.1'
 $zipFile = "emacs-$($softwareVersion)_x64.zip"
 
 $toolsDir = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
@@ -9,9 +9,8 @@ $installPath = Join-Path -Path (Get-ToolsLocation) -ChildPath 'emacs'
 
 $packageArgs = @{
     packageName    = $env:ChocolateyPackageName
-    unzipLocation  = Get-ToolsLocation
+    unzipLocation  = "$(Get-ToolsLocation)\emacs-$softwareVersion"
     fileFullPath   = $filePath
-    specificFolder = "emacs-$softwareVersion"   # we use this so we know what the extracted folder name will be as it has to be this one
 }
 
 Get-ChocolateyUnzip @packageArgs


### PR DESCRIPTION
## Description
The package tests were failing because the zips for 29.1 don't have the `emacs-$version` pattern of earlier releases. I changed the install script to account for the change then ran the AU update.ps1.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
It fixes the issue for 29.1, but it's probably a breaking change for earlier versions, not sure how you'd want to handle that.
<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/pauby/ChocoPackages/issues/199
<!-- Use fixes/fixed when referencing the issue -->

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
I forked this repo, mucked around a bit before finding out the structure of the new and old emacs zips are different. After that, it was pretty clear to modify the parameters sent to `Get-ChocolateyUnzip`, run the AU `update.ps1` and run `choco install emacs.portable --debug --verbose --source .` from the `emacs.portable` directory without issue.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->
Tested on Windows 10 Pro

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository (if your change does not follow the style it will likely be rejected - this includes changes in formatting / layout).
- [x] I have updated the package description and it is less than 4000 characters.
- [ ] The added / modified package passed install / uninstall in the chocolatey test environment.
    I didn't have the time to setup the test environment; but before success, I was getting the same errors as the failed tests for 29.1
- [x] The changes only affect a single package (not including meta package).
